### PR TITLE
fixed legacy persistence handling (filesystemlabel live-rw)

### DIFF
--- a/scripts/live-helpers
+++ b/scripts/live-helpers
@@ -778,6 +778,7 @@ mount_persistence_media ()
 			return 1
 		fi
 	fi
+	echo ${backing}
 	return 0
 }
 
@@ -1334,7 +1335,7 @@ get_custom_mounts ()
 			local source="${dir}"
 			if [ -n "${opt_source}" ]
 			then
-				if echo ${opt_source} | grep -q -e "^/" -e "^\(.*/\)\?\.\.\?\(/.*\)\?$" && [ "${source}" != "." ]
+				if echo ${opt_source} | grep -q -e "^/" -e "^\(.*/\)\?\.\.\?\(/.*\)\?$" && [ "${opt_source}" != "." ]
 				then
 					log_warning_msg "Skipping unsafe custom mount with option source=${opt_source}: must be either \".\" (the media root) or a relative path w.r.t. the media root that contains neither comas, nor the special \".\" and \"..\" path components"
 					continue


### PR DESCRIPTION
- the mount_persistence_media () function must return the mount point of
  the partition to the caller, even if it was already mounted
  (${backing} = ${old_backing})
- Fix the appropriate check that erroneously prevented the use of the
  (unquoted) dot
