### PR TITLE
Allow +2 nameserver entries for dns= boot option

### DIFF
--- a/debian/patches/15_networking_grml.patch
+++ b/debian/patches/15_networking_grml.patch
@@ -120,14 +120,14 @@ Index: live-boot-grml/components/9990-grml-networking.sh
 +done
 +
 +# dns bootoption
-+if [ -n "$DNSSERVER1" ]
++if [ -n "$DNSSERVERS" ]
 +then
 +	# disable any existing entries
 +	if [ -r $RESOLVCONF ]
 +	then
 +		sed -i 's/nameserver/# nameserver/' $RESOLVCONF
 +	fi
-+	for i in $DNSSERVER1 $DNSSERVER2
++	for i in $DNSSERVERS
 +	do
 +		echo "nameserver $i" >> $RESOLVCONF
 +	done

--- a/debian/patches/26_support_dns_bootoption.patch
+++ b/debian/patches/26_support_dns_bootoption.patch
@@ -14,7 +14,7 @@ Index: live-boot-grml/components/9990-networking.sh
  			fi
  
 -			for i in ${IPV4DNS0} ${IPV4DNS1} ${IPV4DNS1}
-+			for i in ${IPV4DNS0} ${IPV4DNS1} ${IPV4DNS1} ${DNSSERVER1} ${DNSSERVER2}
++			for i in ${IPV4DNS0} ${IPV4DNS1} ${IPV4DNS1} ${DNSSERVERS}
  			do
  				if [ -n "$i" ] && [ "$i" != 0.0.0.0 ]
  				then
@@ -27,16 +27,10 @@ Index: live-boot-grml/components/9990-cmdline-old
  				;;
  
 +			dns=*)
-+			  	DNSSERVER="${_PARAMETER#*=}"
-+				if echo "${DNSSERVER}" | grep -q , ; then
-+					DNSSERVER1="${DNSSERVER%,*}"
-+					DNSSERVER2="${DNSSERVER#*,}"
-+					export DNSSERVER1 DNSSERVER2
-+				else
-+					DNSSERVER1="$DNSSERVER"
-+					export DNSSERVER1
-+				fi
-+				unset DNSSERVER
++				DNS=${_PARAMETER#dns=}
++				DNSSERVERS=$(echo ${DNS} | sed 's/,/ /g')
++				export DNSSERVERS
++				unset DNS
 +				;;
 +
  			bootid=*)


### PR DESCRIPTION
Would this change be sufficient to allow more than two nameservers to be entered at live boot? (using the 'dns' boot option)

Apologies for my ignorance if more changes are necessary to solve this problem. Any pointers in the right direction are very welcome, I'm more than happy to learn.

For reference, this has been discussed in issue 1234: http://bts.grml.org/grml/issue1234