### PR TITLE
Merge latest changes in debian-live/live-boot

### DIFF
--- a/backend/initramfs-tools/live.hook
+++ b/backend/initramfs-tools/live.hook
@@ -39,6 +39,16 @@ cp -a /bin/live-boot /lib/live/boot "${DESTDIR}/bin"
 mkdir -p "${DESTDIR}/lib/live"
 cp -a /lib/live/boot "${DESTDIR}/lib/live"
 
+mkdir -p "${DESTDIR}/etc/live"
+if [ -e /etc/live/boot.conf ]
+then
+	cp -a /etc/live/boot.conf "${DESTDIR}/etc/live"
+fi
+if [ -e /etc/live/boot ]
+then
+	cp -a /etc/live/boot "${DESTDIR}/etc/live"
+fi
+
 # klibc dependencies
 for FILE in /lib/libacl* /lib/libblkid* /lib/libuuid* /lib/libdevmapper* /lib/libattr*
 do
@@ -119,6 +129,7 @@ manual_add_modules overlay
 manual_add_modules nls_cp437
 manual_add_modules nls_iso8859-1
 manual_add_modules nls_utf8
+manual_add_modules nls_ascii
 manual_add_modules vfat
 
 # Filesystem: ntfs

--- a/components/9990-misc-helpers.sh
+++ b/components/9990-misc-helpers.sh
@@ -1192,6 +1192,10 @@ removable_dev ()
 
 	for sysblock in $(echo /sys/block/* | tr ' ' '\n' | grep -vE "/(loop|ram|dm-|fd)")
 	do
+		if [ ! -d "${sysblock}" ]; then
+			continue
+		fi
+
 		dev_ok=
 		if [ "$(cat ${sysblock}/removable)" = "1" ]
 		then
@@ -1237,6 +1241,10 @@ non_removable_dev ()
 
 	for sysblock in $(echo /sys/block/* | tr ' ' '\n' | grep -vE "/(loop|ram|dm-|fd)")
 	do
+		if [ ! -d "${sysblock}" ]; then
+			continue
+		fi
+
 		if [ "$(cat ${sysblock}/removable)" = "0" ]
 		then
 			case "${output_format}" in

--- a/components/9990-netbase.sh
+++ b/components/9990-netbase.sh
@@ -68,7 +68,11 @@ EOF
 			fi
 		done
 	else
-		if [ -z "${NETBOOT}" ] || [ -n "${DHCP}" ]
+		if [ -n "${NODHCP}" ]
+		then
+			# force DHCP off
+			method="manual"
+		elif [ -z "${NETBOOT}" ] || [ -n "${DHCP}" ]
 		then
 			# default, dhcp assigned
 			method="dhcp"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+live-boot (1:20170112) unstable; urgency=medium
+
+  [ Raphaël Hertzog ]
+  * Team upload.
+  * Fix nodhcp option to actually force DHCP off. Closes: #785345
+    Thanks to Frank Lillo for the report and Evgeni Golov for the patch.
+  * Improve 9990-misc-helpers.sh when /sys/block/ is empty.
+    Closes: #847802
+  * Multiple cleanups to appease lintian.
+
+  [ Kristian Klausen ]
+  * Add "nls_ascii" module in the initrd so that we can access FAT
+    partitions. Closes: #850532
+  * Copy /etc/live/boot.conf and /etc/live/boot to the initrd.
+
+ -- Raphaël Hertzog <hertzog@debian.org>  Thu, 12 Jan 2017 16:59:49 +0100
+
 live-boot (1:20160511+grml.1) unstable; urgency=medium
 
   The "capetown AKA debconf16" release

--- a/debian/live-boot-grml-initramfs-tools.postinst
+++ b/debian/live-boot-grml-initramfs-tools.postinst
@@ -4,7 +4,7 @@ set -e
 
 case "${1}" in
 	configure)
-		if [ -x /usr/sbin/update-initramfs ] && [ -e /etc/initramfs-tools/initramfs.conf ]
+		if which update-initramfs >/dev/null 2>&1 && [ -e /etc/initramfs-tools/initramfs.conf ]
 		then
 			update-initramfs -u
 		fi

--- a/debian/live-boot-initramfs-tools.postrm
+++ b/debian/live-boot-initramfs-tools.postrm
@@ -4,7 +4,7 @@ set -e
 
 case "${1}" in
 	remove)
-		if [ -x /usr/sbin/update-initramfs ] && [ -e /etc/initramfs-tools/initramfs.conf ]
+		if which update-initramfs >/dev/null 2>&1 && [ -e /etc/initramfs-tools/initramfs.conf ]
 		then
 			update-initramfs -u
 		fi


### PR DESCRIPTION
Hi,

I'm more or less new to this upstream merging and fork pulling so I hope what I'm doing is correct.
Also I don't have grml-live set up so I couldn't test this.

Booting grml with kernel 4.8 from a FAT-formatted drive fails because nls_ascii is missing from the initrd image, see
http://bts.grml.org/grml/issue2451
and
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850532

It was fixed in debian-live/live-boot so I merged that into here, trying to do it as in commit 202dc50.

I wonder if the /etc/live/boot{,conf} part is necessary.