### PR TITLE
9990-misc-helpers.sh: remove mdadm.conf in initramfs if existent.

### DIFF
--- a/components/9990-misc-helpers.sh
+++ b/components/9990-misc-helpers.sh
@@ -268,6 +268,21 @@ check_dev ()
 				# Adding raid support
 				if [ -x /scripts/local-block/mdadm ]
 				then
+					# Before actually doing anything, make sure that no auto-generated
+					# mdadm.conf is around in the initramfs.
+					# Short explanation of why this is needed:
+					# /usr/share/initramfs-tools/hooks/mdadm is executed as part of
+					# mkinitramfs, which generates an /etc/mdadm/mdadm.conf file if one
+					# doesn't exist yet (which should always be the case in our new
+					# chroot) based on the host system configuration. Eventually, this
+					# is copied into the generated initramfs and then causes issues on
+					# other systems.
+					# It's safe to delete the file within the initramfs. The actual
+					# squashfs root will not be affected by that (and, additionally,
+					# a FAI script makes sure that the mdadm.conf in there gets wiped
+					# of any auto-generated arrays).
+					rm -rf '/etc/mdadm/mdadm.conf'
+
 					# Back in the day, when there was still a local-top mdadm script, we
 					# used to select specific devices to be auto-assembled.
 					# This functionality was dropped in the local-block script, so just


### PR DESCRIPTION
`mkinitramfs` is creating the initramfs based on host system parameters.
This is important for RAID support - if the base system (in that case,
the FAI chroot we use to bootstrap grml from) does not contain an
`/etc/mdadm/mdadm.conf` file (which is the default), it will automatically
generate one for the initramfs from the RAID devices in the currently
running system.

This essentially means that the RAID configuration spills into the
initramfs, even if later grml-live/FAI scripts make sure that they are
not recorded in the squashfs `mdadm.conf`.

Consequently, the generated image will boot fine on the system that
created the image, but will fail to boot from RAID devices on other
systems, since `mdadm --assemble --scan` will just refuse to start any
arrays not included in the provided `mdadm.conf` file as shipped in the
initramfs. Since we build general-purpose images and desperately want to
have auto-detection in such a case, this behavior is unwanted.

The easiest way to fix that is to just delete the initramfs's `mdadm.conf`
file before calling the RAID auto-detection script. This should restore
correct auto-detection behavior regardless of the system that built the
image without any disadvantage.

Closes: https://github.com/grml/grml/issues/125