### PR TITLE
Update 9990-select-eth-device.sh for multiple network devices with UEFI

### DIFF
--- a/components/9990-select-eth-device.sh
+++ b/components/9990-select-eth-device.sh
@@ -103,7 +103,6 @@ Select_eth_device ()
                             return
                             ;;
                         esac
-
 		done
 	else
 		l_interfaces="$DEVICE"


### PR DESCRIPTION
Update live-netdev to alternatively use a given mac address for the active network device.

Background: Legacy has IPAPPEND 2 to force a device in grml. UEFI does not have this mechanism. So we need an alternative for machines with mulitple network devices. Some motherboards swap the device names so eth0 becomes eth1. And then the live-netdev=eth0 fails.

It takes the mac, checks which device name this mac has and uses the device name then to fire up the network connection.

format is "live-netdev=xx:xx:xx:xx:xx:xx"

This patch was developed by Thomas Toka / Serverman Webhosting.

Thanks to @mika for the hints to find the relevant code.