### PR TITLE
Disable set -e in live.hook

### DIFF
--- a/backend/initramfs-tools/live.hook
+++ b/backend/initramfs-tools/live.hook
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-set -e
+# disabled as a workaround for #1099461
+#set -e
 
 . /usr/share/initramfs-tools/hook-functions
 


### PR DESCRIPTION
Workaround for Debian bug #1099461 in initramfs-tools. Specifically, initramfs-tools is not designed to run hooks with "set -e", even though this worked in the past.
Since initramfs-tools 0.146, initramfs-tools' hooks-functions unconditionally reads from /sys/module/firmware_class/parameters/path. This fails in our build environment, as /sys is not mounted. Because of the "set -e", then the entire initramfs build is aborted with error 2.

Somebody also should send a patch to Debian's initramfs-tools to make this workaround unnecessary.