### PR TITLE
Revert "Disable set -e in live.hook"

### DIFF
--- a/backend/initramfs-tools/live.hook
+++ b/backend/initramfs-tools/live.hook
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-# disabled as a workaround for #1099461
-#set -e
+set -e
 
 . /usr/share/initramfs-tools/hook-functions
 


### PR DESCRIPTION
Debian bug #1099461 was fixed in initramfs-tools 0.147.

The workaround introduced in 0047259dd7c8ce69af973baada268359e7d11104 should not be necessary anymore.